### PR TITLE
Implement semantic header with navigation and logo

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -8,27 +8,43 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html" class="active">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Contacto</h1>
-  <div class="section">
-    <p><strong>Tel.</strong> 653 794 749<br><strong>Email</strong> info@garenta.es</p>
+  <div class="container">
+    <h1>Contacto</h1>
+    <div class="section">
+      <p><strong>Tel.</strong> 653 794 749<br><strong>Email</strong> info@garenta.es</p>
+    </div>
+    <div class="section">
+      <h3>Solicita tu propuesta</h3>
+      <form method="post" action="#">
+        <div style="display:flex;flex-direction:column;gap:8px">
+          <input type="text" name="nombre" placeholder="Nombre y apellidos" required style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
+          <input type="tel" name="telefono" placeholder="Teléfono" required style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
+          <input type="email" name="email" placeholder="Email" style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
+          <textarea name="comentarios" placeholder="Comentarios" rows="4" style="padding:10px;border-radius:8px;border:1px solid #dfe6ee"></textarea>
+          <button class="btn" type="submit">Enviar</button>
+        </div>
+      </form>
+    </div>
+    <div class="footer">© Garenta</div>
   </div>
-  <div class="section">
-    <h3>Solicita tu propuesta</h3>
-    <form method="post" action="#">
-      <div style="display:flex;flex-direction:column;gap:8px">
-        <input type="text" name="nombre" placeholder="Nombre y apellidos" required style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
-        <input type="tel" name="telefono" placeholder="Teléfono" required style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
-        <input type="email" name="email" placeholder="Email" style="padding:10px;border-radius:8px;border:1px solid #dfe6ee">
-        <textarea name="comentarios" placeholder="Comentarios" rows="4" style="padding:10px;border-radius:8px;border:1px solid #dfe6ee"></textarea>
-        <button class="btn" type="submit">Enviar</button>
-      </div>
-    </form>
-  </div>
-  <div class="footer">© Garenta</div>
-</div>
 
   <script src="js/main.js" defer></script>
   <script src="js/forms.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -8,31 +8,47 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html" class="active">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Alquila tu propiedad sin riesgo. Te garantizamos la renta el Día 1</h1>
-  <p><em>Con Garenta, cobras el Día 1 de cada mes y garantizas tu tranquilidad.</em></p>
-  <div class="section">
-    <h2>Por qué Garenta</h2>
-    <ul class="list">
-      <li>Impagos y retrasos: tensión de caja y trámites interminables.</li>
-      <li>Papeleo y normativa: contratos, prórrogas, actualizaciones y fianzas.</li>
-      <li>Limpieza y mantenimiento: coordinación y control de calidad.</li>
-      <li>Vacancia: cada mes vacío es rentabilidad perdida.</li>
-    </ul>
-    <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
+  <div class="container">
+    <h1>Alquila tu propiedad sin riesgo. Te garantizamos la renta el Día 1</h1>
+    <p><em>Con Garenta, cobras el Día 1 de cada mes y garantizas tu tranquilidad.</em></p>
+    <div class="section">
+      <h2>Por qué Garenta</h2>
+      <ul class="list">
+        <li>Impagos y retrasos: tensión de caja y trámites interminables.</li>
+        <li>Papeleo y normativa: contratos, prórrogas, actualizaciones y fianzas.</li>
+        <li>Limpieza y mantenimiento: coordinación y control de calidad.</li>
+        <li>Vacancia: cada mes vacío es rentabilidad perdida.</li>
+      </ul>
+      <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
+    </div>
+    <div class="section">
+      <h2>Nuestra promesa</h2>
+      <ul class="list">
+        <li><strong>Pago Día 1</strong>: cobras el primer día de cada mes mientras la vivienda esté ocupada.</li>
+        <li><strong>Defensa jurídica</strong>: actuamos en impagos y reclamaciones.</li>
+        <li><strong>Gestión 360º</strong>: desde la puesta a punto hasta los cobros.</li>
+      </ul>
+    </div>
+    <div class="footer">© Garenta · Tel. 653 794 749 · info@garenta.es</div>
   </div>
-  <div class="section">
-    <h2>Nuestra promesa</h2>
-    <ul class="list">
-      <li><strong>Pago Día 1</strong>: cobras el primer día de cada mes mientras la vivienda esté ocupada.</li>
-      <li><strong>Defensa jurídica</strong>: actuamos en impagos y reclamaciones.</li>
-      <li><strong>Gestión 360º</strong>: desde la puesta a punto hasta los cobros.</li>
-    </ul>
-  </div>
-  <div class="footer">© Garenta · Tel. 653 794 749 · info@garenta.es</div>
-</div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/legal-seguridad.html
+++ b/legal-seguridad.html
@@ -8,21 +8,37 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html" class="active">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Legal y seguridad</h1>
-  <div class="section">
-    <ul class="list">
-      <li>Duración y prórrogas conforme a LAU</li>
-      <li>Fianzas y depósitos según normativa</li>
-      <li>Alarmas de plazos y avisos automáticos</li>
-      <li>Defensa jurídica en caso de impago (plan Plus)</li>
-    </ul>
+  <div class="container">
+    <h1>Legal y seguridad</h1>
+    <div class="section">
+      <ul class="list">
+        <li>Duración y prórrogas conforme a LAU</li>
+        <li>Fianzas y depósitos según normativa</li>
+        <li>Alarmas de plazos y avisos automáticos</li>
+        <li>Defensa jurídica en caso de impago (plan Plus)</li>
+      </ul>
+    </div>
+    <a class="btn" href="planes.html">Ver planes</a>
+    <div class="footer">© Garenta</div>
   </div>
-  <a class="btn" href="planes.html">Ver planes</a>
-  <div class="footer">© Garenta</div>
-</div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/metodo.html
+++ b/metodo.html
@@ -8,21 +8,37 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html" class="active">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Método Garenta</h1>
-  <ol class="section list">
-    <li>Valoración y plan</li>
-    <li>Preparación</li>
-    <li>Lanzamiento</li>
-    <li>Filtro y elección</li>
-    <li>Contrato e inicio</li>
-    <li>Gestión mensual</li>
-  </ol>
-  <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
-  <div class="footer">© Garenta</div>
-</div>
+  <div class="container">
+    <h1>Método Garenta</h1>
+    <ol class="section list">
+      <li>Valoración y plan</li>
+      <li>Preparación</li>
+      <li>Lanzamiento</li>
+      <li>Filtro y elección</li>
+      <li>Contrato e inicio</li>
+      <li>Gestión mensual</li>
+    </ol>
+    <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
+    <div class="footer">© Garenta</div>
+  </div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/planes.html
+++ b/planes.html
@@ -8,21 +8,37 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html" class="active">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Planes</h1>
-  <div class="section">
-    <h3>Garenta</h3>
-    <p>6% + IVA — Gestión integral 360º</p>
+  <div class="container">
+    <h1>Planes</h1>
+    <div class="section">
+      <h3>Garenta</h3>
+      <p>6% + IVA — Gestión integral 360º</p>
+    </div>
+    <div class="section">
+      <h3>Garenta Plus</h3>
+      <p>10% + IVA — Pago Día 1 + Defensa jurídica</p>
+    </div>
+    <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
+    <div class="footer">© Garenta</div>
   </div>
-  <div class="section">
-    <h3>Garenta Plus</h3>
-    <p>10% + IVA — Pago Día 1 + Defensa jurídica</p>
-  </div>
-  <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
-  <div class="footer">© Garenta</div>
-</div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/privacidad.html
+++ b/privacidad.html
@@ -8,15 +8,31 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html" class="active">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Política de privacidad</h1>
-  <div class="section">
-    <p>Responsable: Garenta. Finalidad: atender solicitudes y prestar servicios de gestión de alquiler. Derechos: acceso, rectificación y supresión en info@garenta.es.</p>
+  <div class="container">
+    <h1>Política de privacidad</h1>
+    <div class="section">
+      <p>Responsable: Garenta. Finalidad: atender solicitudes y prestar servicios de gestión de alquiler. Derechos: acceso, rectificación y supresión en info@garenta.es.</p>
+    </div>
+    <div class="footer">© Garenta</div>
   </div>
-  <div class="footer">© Garenta</div>
-</div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/seleccion-inquilinos.html
+++ b/seleccion-inquilinos.html
@@ -8,20 +8,36 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html" class="active">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Selección de inquilinos</h1>
-  <div class="section">
-    <ul class="list">
-      <li><strong>Scoring financiero y laboral</strong></li>
-      <li><strong>Verificación documental</strong> (nóminas, vida laboral)</li>
-      <li><strong>Consultas a ficheros</strong> y políticas de garantía</li>
-    </ul>
+  <div class="container">
+    <h1>Selección de inquilinos</h1>
+    <div class="section">
+      <ul class="list">
+        <li><strong>Scoring financiero y laboral</strong></li>
+        <li><strong>Verificación documental</strong> (nóminas, vida laboral)</li>
+        <li><strong>Consultas a ficheros</strong> y políticas de garantía</li>
+      </ul>
+    </div>
+    <a class="btn" href="contacto.html">Contactar</a>
+    <div class="footer">© Garenta</div>
   </div>
-  <a class="btn" href="contacto.html">Contactar</a>
-  <div class="footer">© Garenta</div>
-</div>
 
   <script src="js/main.js" defer></script>
 </body>

--- a/servicios.html
+++ b/servicios.html
@@ -8,25 +8,41 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="index.html">
+        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+      </a>
+      <nav class="primary">
+        <a href="index.html">Inicio</a>
+        <a href="metodo.html">Método</a>
+        <a href="servicios.html" class="active">Servicios</a>
+        <a href="planes.html">Planes</a>
+        <a href="seleccion-inquilinos.html">Selección</a>
+        <a href="legal-seguridad.html">Legal</a>
+        <a href="privacidad.html">Privacidad</a>
+        <a href="contacto.html">Contacto</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="container">
-  <div class="header"><div class="logo-mark" aria-hidden="true"></div><strong>garenta</strong></div>
-  <h1>Qué hacemos por ti</h1>
-  <p class="section">
-    <strong>Puesta a punto</strong><br>Precio objetivo, checklist técnico e inventario.
-  </p>
-  <p class="section">
-    <strong>Salida al mercado</strong><br>Fotos/planos, difusión en portales y visitas.
-  </p>
-  <p class="section">
-    <strong>Selección</strong><br>Scoring, verificaciones y control de riesgos.
-  </p>
-  <p class="section">
-    <strong>Limpieza y mantenimientos</strong><br>Coordinación de limpiezas, mantenimiento preventivo y control de calidad.
-  </p>
-  <a class="btn" href="contacto.html">Solicitar propuesta</a>
-  <div class="footer">© Garenta</div>
-</div>
+  <div class="container">
+    <h1>Qué hacemos por ti</h1>
+    <p class="section">
+      <strong>Puesta a punto</strong><br>Precio objetivo, checklist técnico e inventario.
+    </p>
+    <p class="section">
+      <strong>Salida al mercado</strong><br>Fotos/planos, difusión en portales y visitas.
+    </p>
+    <p class="section">
+      <strong>Selección</strong><br>Scoring, verificaciones y control de riesgos.
+    </p>
+    <p class="section">
+      <strong>Limpieza y mantenimientos</strong><br>Coordinación de limpiezas, mantenimiento preventivo y control de calidad.
+    </p>
+    <a class="btn" href="contacto.html">Solicitar propuesta</a>
+    <div class="footer">© Garenta</div>
+  </div>
 
   <script src="js/main.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- Replace ad hoc header with semantic `<header>` containing nav links for all pages
- Add Garenta logo image from `assets/img` and highlight active page per view

## Testing
- `npx --yes htmlhint "*.html"`

------
https://chatgpt.com/codex/tasks/task_b_68baaf126728832da028b687b15a28dd