### PR TITLE
Reemplaza elementos genéricos por imágenes

### DIFF
--- a/contacto.html
+++ b/contacto.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,9 +29,11 @@
   <div class="container">
     <h1>Contacto</h1>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <p><strong>Tel.</strong> 653 794 749<br><strong>Email</strong> info@garenta.es</p>
     </div>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <h3>Solicita tu propuesta</h3>
       <form method="post" action="#">
         <div style="display:flex;flex-direction:column;gap:8px">

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html" class="active">Inicio</a>
@@ -30,6 +30,7 @@
     <h1>Alquila tu propiedad sin riesgo. Te garantizamos la renta el Día 1</h1>
     <p><em>Con Garenta, cobras el Día 1 de cada mes y garantizas tu tranquilidad.</em></p>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <h2>Por qué Garenta</h2>
       <ul class="list">
         <li>Impagos y retrasos: tensión de caja y trámites interminables.</li>
@@ -40,6 +41,7 @@
       <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
     </div>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <h2>Nuestra promesa</h2>
       <ul class="list">
         <li><strong>Pago Día 1</strong>: cobras el primer día de cada mes mientras la vivienda esté ocupada.</li>

--- a/legal-seguridad.html
+++ b/legal-seguridad.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,6 +29,7 @@
   <div class="container">
     <h1>Legal y seguridad</h1>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <ul class="list">
         <li>Duración y prórrogas conforme a LAU</li>
         <li>Fianzas y depósitos según normativa</li>

--- a/metodo.html
+++ b/metodo.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -28,14 +28,17 @@
 
   <div class="container">
     <h1>Método Garenta</h1>
-    <ol class="section list">
-      <li>Valoración y plan</li>
-      <li>Preparación</li>
-      <li>Lanzamiento</li>
-      <li>Filtro y elección</li>
-      <li>Contrato e inicio</li>
-      <li>Gestión mensual</li>
-    </ol>
+    <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
+      <ol class="list">
+        <li>Valoración y plan</li>
+        <li>Preparación</li>
+        <li>Lanzamiento</li>
+        <li>Filtro y elección</li>
+        <li>Contrato e inicio</li>
+        <li>Gestión mensual</li>
+      </ol>
+    </div>
     <a class="btn" href="contacto.html">Quiero garantizar mi alquiler</a>
     <div class="footer">© Garenta</div>
   </div>

--- a/planes.html
+++ b/planes.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,10 +29,12 @@
   <div class="container">
     <h1>Planes</h1>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <h3>Garenta</h3>
       <p>6% + IVA — Gestión integral 360º</p>
     </div>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <h3>Garenta Plus</h3>
       <p>10% + IVA — Pago Día 1 + Defensa jurídica</p>
     </div>

--- a/privacidad.html
+++ b/privacidad.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,6 +29,7 @@
   <div class="container">
     <h1>Política de privacidad</h1>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <p>Responsable: Garenta. Finalidad: atender solicitudes y prestar servicios de gestión de alquiler. Derechos: acceso, rectificación y supresión en info@garenta.es.</p>
     </div>
     <div class="footer">© Garenta</div>

--- a/seleccion-inquilinos.html
+++ b/seleccion-inquilinos.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,6 +29,7 @@
   <div class="container">
     <h1>Selección de inquilinos</h1>
     <div class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <ul class="list">
         <li><strong>Scoring financiero y laboral</strong></li>
         <li><strong>Verificación documental</strong> (nóminas, vida laboral)</li>

--- a/servicios.html
+++ b/servicios.html
@@ -11,7 +11,7 @@
   <header>
     <div class="container nav">
       <a class="logo" href="index.html">
-        <img src="assets/img/logo.svg" alt="Garenta"> garenta
+        <img src="assets/img/logo.svg" alt="Logo de Garenta">
       </a>
       <nav class="primary">
         <a href="index.html">Inicio</a>
@@ -29,15 +29,19 @@
   <div class="container">
     <h1>Qué hacemos por ti</h1>
     <p class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <strong>Puesta a punto</strong><br>Precio objetivo, checklist técnico e inventario.
     </p>
     <p class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <strong>Salida al mercado</strong><br>Fotos/planos, difusión en portales y visitas.
     </p>
     <p class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <strong>Selección</strong><br>Scoring, verificaciones y control de riesgos.
     </p>
     <p class="section">
+      <img src="assets/img/triangulo.svg" alt="Triángulo decorativo">
       <strong>Limpieza y mantenimientos</strong><br>Coordinación de limpiezas, mantenimiento preventivo y control de calidad.
     </p>
     <a class="btn" href="contacto.html">Solicitar propuesta</a>


### PR DESCRIPTION
## Summary
- Sustituye texto y elementos genéricos por imágenes del directorio `assets/img`
- Añade `triangulo.svg` como decoración en secciones de todas las páginas
- Ajusta los atributos `alt` para describir cada imagen y asegura rutas relativas

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_b_68baaff4f43c832dadb58d0c780a6679